### PR TITLE
fix: [#5] Fixed Twitter logo broken bug

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -9,7 +9,7 @@ const Footer = () => {
                 <div><img src={logo} alt="Logo" /></div>
                 <div className='flex justify-center items-center space-x-4'>
                     <h2  className=' text-xl lg:text-2xl'>Twitter</h2>
-                        <a href='https://twitter.com/DevMatrix1' target='_blank'><img src="./src/assets/link.png" alt="Logo" className='w-8 h-8' /></a>
+                        <a href='https://twitter.com/DevMatrix1' target='_blank'><img src={link} alt="Logo" className='w-8 h-8' /></a>
                 </div>
                 <div className='flex justify-center items-center space-x-4'>
                         <h2  className=' text-xl lg:text-2xl'>Github</h2>


### PR DESCRIPTION
### **Scope of change**
Twitter logo not working correctly is fixed by changing the img src adding logic.

### **Screenshots**
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/87971509/235145703-b223cd73-1a6b-4e59-9afd-13ca6b559a8c.png">

### Note
This PR fixes #5 